### PR TITLE
Drop 'redislite' requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 DateUtils==0.6.6
 hiredis==0.1.1
 redis>=2.7.5
-redislite>=1.0.228


### PR DESCRIPTION
Since `redislite` is never used anywhere in this module, its removal from `requirements.txt` is a most natural step.